### PR TITLE
[KAFKA-192] Change latency calculations in kafka fork

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -34,6 +34,7 @@ import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -176,7 +177,16 @@ public class MirrorSourceTask extends SourceTask {
             return;
         }
         TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
-        long latency = System.currentTimeMillis() - record.timestamp();
+        long correctedTimestamp = record.timestamp();
+        Header eventProxiedTimeHeader = (Header) record.headers().lastWithName("eventProxiedTime");  // TODO: change to standardized header name when available
+        if (eventProxiedTimeHeader != null) {
+            try {
+                correctedTimestamp = Long.parseLong(new String(eventProxiedTimeHeader.value(), StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                log.error("Error parsing eventProxiedTime header value '{}' -- using record timestamp instead.", eventProxiedTimeHeader.value(), e);
+            }
+        }
+        long latency = System.currentTimeMillis() - correctedTimestamp;
         metrics.countRecord(topicPartition);
         metrics.replicationLatency(topicPartition, latency);
         // Queue offset syncs only when offsetWriter is available

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -180,10 +180,11 @@ public class MirrorSourceTask extends SourceTask {
         long correctedTimestamp = record.timestamp();
         Header eventProxiedTimeHeader = (Header) record.headers().lastWithName("eventProxiedTime");  // TODO: change to standardized header name when available
         if (eventProxiedTimeHeader != null) {
+            String headerString = new String(eventProxiedTimeHeader.value(), StandardCharsets.UTF_8);
             try {
-                correctedTimestamp = Long.parseLong(new String(eventProxiedTimeHeader.value(), StandardCharsets.UTF_8));
-            } catch (Exception e) {
-                log.error("Error parsing eventProxiedTime header value '{}' -- using record timestamp instead.", eventProxiedTimeHeader.value(), e);
+                correctedTimestamp = Long.parseLong(headerString);
+            } catch (NumberFormatException e) {
+                log.error("Error parsing eventProxiedTime header value '{}' -- using record timestamp instead.", headerString, e);
             }
         }
         long latency = System.currentTimeMillis() - correctedTimestamp;


### PR DESCRIPTION
## Context

If present, use `eventProxiedTime` header. Otherwise, use `record.timestamp()`. 

`eventProxiedTime` header should be replaced by standardized header name when available.