### PR TITLE
[KAFKA-192] Fix latency calculations

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -178,6 +178,7 @@ public class MirrorSourceTask extends SourceTask {
         }
         TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
         long correctedTimestamp = record.timestamp();
+        long currentTimeMillis = System.currentTimeMillis();
         Header eventProxiedTimeHeader = (Header) record.headers().lastWithName("eventProxiedTime");  // TODO: change to standardized header name when available
         if (eventProxiedTimeHeader != null) {
             String headerString = new String(eventProxiedTimeHeader.value(), StandardCharsets.UTF_8);
@@ -187,7 +188,7 @@ public class MirrorSourceTask extends SourceTask {
                 log.error("Error parsing eventProxiedTime header value '{}' -- using record timestamp instead.", headerString, e);
             }
         }
-        long latency = System.currentTimeMillis() - correctedTimestamp;
+        long latency = currentTimeMillis - correctedTimestamp;
         metrics.countRecord(topicPartition);
         metrics.replicationLatency(topicPartition, latency);
         // Queue offset syncs only when offsetWriter is available


### PR DESCRIPTION
## Context

I checked couple of StreamingEngine topics and seems like replication latency (on graphics) only increased after https://github.com/transferwise/kafka/pull/2. 
(at 15:45)
<img width="1544" height="654" alt="image" src="https://github.com/user-attachments/assets/71fcbeaf-21fc-47cd-b7c0-dd967b22eb80" />

One possible explanation is that maybe we should save `System.currentTimeMillis()` at the beginning, and only then do calculations with `eventProxiedTimeHeader`.